### PR TITLE
fix(url-normalization): Saver url handling for prod env

### DIFF
--- a/src/Api.ToMcp.Runtime/Api.ToMcp.Runtime.csproj
+++ b/src/Api.ToMcp.Runtime/Api.ToMcp.Runtime.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Api.ToMcp.Runtime.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/Api.ToMcp.Runtime/Services/DefaultBaseUrlProvider.cs
+++ b/src/Api.ToMcp.Runtime/Services/DefaultBaseUrlProvider.cs
@@ -59,7 +59,7 @@ public sealed class DefaultBaseUrlProvider : ISelfBaseUrlProvider
                     .FirstOrDefault(a => a.StartsWith("https://"))
                     ?? addressFeature.Addresses.First();
 
-                _cachedUrl = address.TrimEnd('/');
+                _cachedUrl = NormalizeBindingAddress(address);
                 return _cachedUrl;
             }
 
@@ -67,5 +67,58 @@ public sealed class DefaultBaseUrlProvider : ISelfBaseUrlProvider
                 "Unable to determine base URL. Configure 'McpTools:BaseUrl' in appsettings.json " +
                 "or ensure the server has started before calling GetBaseUrl().");
         }
+    }
+
+    /// <summary>
+    /// Normalizes wildcard binding addresses (e.g., http://+:80, http://0.0.0.0:80, http://[::]:80)
+    /// into localhost addresses that are valid for HTTP client self-calls.
+    /// Uri constructor cannot be used here because hosts like "+" and "*" are not valid URIs.
+    /// </summary>
+    internal static string NormalizeBindingAddress(string address)
+    {
+        var trimmed = address.TrimEnd('/');
+
+        var schemeEnd = trimmed.IndexOf("://", StringComparison.Ordinal);
+        if (schemeEnd < 0)
+            return trimmed;
+
+        var scheme = trimmed[..schemeEnd];
+        var afterScheme = trimmed[(schemeEnd + 3)..];
+
+        string host;
+        string rest;
+
+        if (afterScheme.StartsWith("["))
+        {
+            // IPv6 address in brackets, e.g. [::]:80
+            var bracketEnd = afterScheme.IndexOf(']');
+            if (bracketEnd < 0)
+                return trimmed;
+
+            host = afterScheme[..(bracketEnd + 1)];
+            rest = afterScheme[(bracketEnd + 1)..];
+        }
+        else
+        {
+            var hostEnd = afterScheme.IndexOfAny([':', '/']);
+            if (hostEnd < 0)
+            {
+                host = afterScheme;
+                rest = "";
+            }
+            else
+            {
+                host = afterScheme[..hostEnd];
+                rest = afterScheme[hostEnd..];
+            }
+        }
+
+        string[] wildcardHosts = ["+", "*", "0.0.0.0", "[::]", "[::1]"];
+        if (wildcardHosts.Any(w => string.Equals(host, w, StringComparison.OrdinalIgnoreCase)))
+        {
+            return $"{scheme}://localhost{rest}";
+        }
+
+        return trimmed;
     }
 }

--- a/tests/Api.ToMcp.Runtime.Tests/Services/DefaultBaseUrlProviderTests.cs
+++ b/tests/Api.ToMcp.Runtime.Tests/Services/DefaultBaseUrlProviderTests.cs
@@ -1,0 +1,54 @@
+using Api.ToMcp.Runtime.Services;
+using Xunit;
+
+namespace Api.ToMcp.Runtime.Tests.Services;
+
+public class DefaultBaseUrlProviderTests
+{
+    [Theory]
+    [InlineData("http://+:80", "http://localhost:80")]
+    [InlineData("http://*:80", "http://localhost:80")]
+    [InlineData("http://0.0.0.0:80", "http://localhost:80")]
+    [InlineData("http://[::]:80", "http://localhost:80")]
+    [InlineData("http://[::1]:80", "http://localhost:80")]
+    [InlineData("https://+:443", "https://localhost:443")]
+    [InlineData("https://*:443", "https://localhost:443")]
+    [InlineData("http://+:8080", "http://localhost:8080")]
+    [InlineData("http://0.0.0.0:5000", "http://localhost:5000")]
+    [InlineData("http://[::]:5000", "http://localhost:5000")]
+    public void NormalizeBindingAddress_ReplacesWildcardHosts_WithLocalhost(string input, string expected)
+    {
+        var result = DefaultBaseUrlProvider.NormalizeBindingAddress(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("https://localhost:5001", "https://localhost:5001")]
+    [InlineData("http://localhost:5000", "http://localhost:5000")]
+    [InlineData("https://myapp.azurewebsites.net", "https://myapp.azurewebsites.net")]
+    [InlineData("http://10.0.0.5:8080", "http://10.0.0.5:8080")]
+    public void NormalizeBindingAddress_PreservesValidAddresses(string input, string expected)
+    {
+        var result = DefaultBaseUrlProvider.NormalizeBindingAddress(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("http://+:80/", "http://localhost:80")]
+    [InlineData("https://localhost:5001/", "https://localhost:5001")]
+    public void NormalizeBindingAddress_TrimsTrailingSlash(string input, string expected)
+    {
+        var result = DefaultBaseUrlProvider.NormalizeBindingAddress(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("http://+", "http://localhost")]
+    [InlineData("http://*", "http://localhost")]
+    [InlineData("http://0.0.0.0", "http://localhost")]
+    public void NormalizeBindingAddress_HandlesNoPort(string input, string expected)
+    {
+        var result = DefaultBaseUrlProvider.NormalizeBindingAddress(input);
+        Assert.Equal(expected, result);
+    }
+}


### PR DESCRIPTION
  - DefaultBaseUrlProvider.GetBaseUrl() falls back to IServerAddressesFeature when McpTools:BaseUrl is
   not configured. In production deployments (Azure App Service, Docker, etc.), Kestrel binds to
  wildcard addresses like http://+:80, http://0.0.0.0:8080, or http://[::]:80. These are valid for
  listening but not valid hostnames for HttpClient requests.
  - When McpHttpInvoker tries to self-call the API (e.g., GET http://+:80/api/...), the request fails
  because +, *, 0.0.0.0, etc. are not resolvable hostnames.
  - Added NormalizeBindingAddress() that detects wildcard hosts and replaces them with localhost, so
  http://+:80 becomes http://localhost:80.